### PR TITLE
Fixed AE + IC2 energy overflow

### DIFF
--- a/de/thexxturboxx/blockhelper/integration/AppEngIntegration.java
+++ b/de/thexxturboxx/blockhelper/integration/AppEngIntegration.java
@@ -15,6 +15,9 @@ public class AppEngIntegration extends BlockHelperInfoProvider {
             TilePoweredBase tpb = (TilePoweredBase) state.te;
             float stored = tpb.storedPower;
             float max = tpb.maxStoredPower;
+            if (stored > max) {
+                stored = max;
+            }
             if (max != 0) {
                 info.add(stored + " AE / " + max + " AE");
             }
@@ -22,6 +25,9 @@ public class AppEngIntegration extends BlockHelperInfoProvider {
             IMEPowerStorage ps = (IMEPowerStorage) state.te;
             double stored = ps.getMECurrentPower();
             double max = ps.getMEMaxPower();
+            if (stored > max) {
+                stored = max;
+            }
             if (max != 0) {
                 info.add(stored + " AE / " + max + " AE");
             }


### PR DESCRIPTION
Currently when powering AE block directly using IC2 cables the current storage is greater than max capacity.
This should fix the issue.

![image](https://github.com/ThexXTURBOXx/BlockHelper/assets/25727222/d339a9ec-50a7-473b-8ffa-78600e99c952)


https://github.com/ThexXTURBOXx/BlockHelper/assets/25727222/8c0aed32-cbaa-4975-be87-b8615b90cd2b

